### PR TITLE
[ROS] fixed error appearing in keyboard_control.launch

### DIFF
--- a/install_pkgs.sh
+++ b/install_pkgs.sh
@@ -22,6 +22,7 @@ sudo apt install ros-$ROS_DISTRO-base-local-planner \
 					ros-$ROS_DISTRO-tf2-eigen \
 					ros-$ROS_DISTRO-compressed-image-transport \
 					ros-$ROS_DISTRO-interactive-markers \
+					ros-$ROS_DISTRO-key-teleop \
 					qt5-default \
 					libsuitesparse-dev 
 


### PR DESCRIPTION
При запуске скрипта для управления роботом
`roslaunch wr8_software keyboard_control.launch`
возникает ошибка:
```
ERROR: cannot launch node of type [key_teleop/key_teleop.py]: key_teleop
ROS path [0]=/opt/ros/melodic/share/ros
ROS path [1]=/home/dmitriy/ros_workspace/src
ROS path [2]=/opt/ros/melodic/share
```
Очевидно, не хватает пакета key_teleop. Если его установить, то все ок
`sudo apt install ros-melodic-key-teleop`
Чтобы вручную не устанавливать, можно его добавить в install_pkgs.sh.


