### PR TITLE
[ROS] fix hector_slam dependence: replace qt5 with qt4

### DIFF
--- a/install_pkgs.sh
+++ b/install_pkgs.sh
@@ -25,7 +25,7 @@ sudo apt install ros-$ROS_DISTRO-base-local-planner \
 					ros-$ROS_DISTRO-interactive-markers \
 					ros-$ROS_DISTRO-key-teleop \
 					ros-$ROS_DISTRO-gmapping \
-					qt5-default \
+					qt4-default \
 					libsuitesparse-dev 
 
 # git -C wr8_gui_server/smart_vehicle_gui pull 	|| git -C wr8_gui_server clone https://github.com/lilSpeedwagon/smart_vehicle_gui.git


### PR DESCRIPTION
В `install_pkgs.sh` в [коммите 1b9c4d от 22 сентября](https://github.com/PonomarevDA/zaWRka-project/commit/1b9c4d8094df43d103e358875d3a676382318a6c) пакет `qt4-default` был заменен на `qt5-default`.
До этого catkin_make на ubuntu 18.04 успешно работал. Сейчас не работает.
[Согласно CMakeLists.txt](https://github.com/tu-darmstadt-ros-pkg/hector_slam/blob/2c3c44942a47c44918e0144624d141c6ec4e99d3/hector_geotiff/CMakeLists.txt#L12) hector_slam/hector_geotiff требует qt4.
О том, что разработчики пакета хотели действительно именно qt4 говорит и [issue, созданное у них в репозитории](https://github.com/tu-darmstadt-ros-pkg/hector_slam/issues/59).
Установил qt4, все заработало.
К сожалению, установка qt4 замещает qt5 и наоборот.
Поэтому предлагаю вернуть, как было :)