### PR TITLE
add simple catkin build workflow

### DIFF
--- a/.github/workflows/catkin_build.yml
+++ b/.github/workflows/catkin_build.yml
@@ -1,0 +1,58 @@
+name: catkin_build
+
+on: [push]
+
+defaults:
+  run:
+    shell: bash
+jobs:
+  catkin_build:
+    runs-on: ubuntu-18.04
+    container:
+      image: ros:melodic
+    steps:
+      # 1. Install basic requirements
+      - name: Force Install GIT latest since actions/checkout@v2 has some problems on ubuntu-18.04 with submodules. The default git version 2.17.1, but it requires at least 2.18.
+        run: |
+          apt-get update                                                    &&  \
+          apt-get upgrade -y                                                &&  \
+          apt-get install -y software-properties-common                     &&  \
+          add-apt-repository -y ppa:git-core/ppa                            &&  \
+          apt-get update                                                    &&  \
+          apt-get install -y git
+      - name: Default ubuntu-18.04 version of python3 is 3.6.9. But numpy==1.12.1 from requirements.txt is supported only since 3.7.
+        run: |
+          apt-get install -y python3.7-dev python3-pip
+
+      # 2. Init workspace
+      - name: Create the folder for the repo
+        run: mkdir -p catkin_ws/src/zaWRka-project
+      - name: Init workspace
+        run: |
+          apt-get install -y python3-catkin-tools                           &&  \
+          cd catkin_ws                                                      &&  \
+          catkin init                                                       &&  \
+          wstool init src                                                   &&  \
+          rosdep update
+
+      # 3. Checkout repo with submodules
+      - uses: actions/checkout@v2
+        with:
+          path: catkin_ws/src/zaWRka-project
+          submodules: recursive
+
+      # 4. Install requirements
+      - name: Install requirements
+        run: |
+          cd catkin_ws/src/zaWRka-project                                   &&  \
+          python3.7 -m pip install Cython                                   &&  \
+          python3.7 -m pip install -r requirements.txt                      &&  \
+          ./scripts/install_pkgs.sh -y                                      &&  \
+          ./scripts/install_third_party.sh
+
+      # 5. Build
+      - name: catkin build
+        run: |
+          source /opt/ros/melodic/setup.bash                                &&  \
+          cd catkin_ws/src/zaWRka-project                                   &&  \
+          ./scripts/build.sh

--- a/.github/workflows/catkin_build.yml
+++ b/.github/workflows/catkin_build.yml
@@ -7,9 +7,9 @@ defaults:
     shell: bash
 jobs:
   catkin_build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
-      image: ros:melodic
+      image: ros:noetic
     steps:
       # 1. Install basic requirements
       - name: Force Install GIT latest since actions/checkout@v2 has some problems on ubuntu-18.04 with submodules. The default git version 2.17.1, but it requires at least 2.18.
@@ -22,7 +22,7 @@ jobs:
           apt-get install -y git
       - name: Default ubuntu-18.04 version of python3 is 3.6.9. But numpy==1.12.1 from requirements.txt is supported only since 3.7.
         run: |
-          apt-get install -y python3.7-dev python3-pip
+          apt-get install -y python3.8-dev python3-pip
 
       # 2. Init workspace
       - name: Create the folder for the repo
@@ -45,14 +45,14 @@ jobs:
       - name: Install requirements
         run: |
           cd catkin_ws/src/zaWRka-project                                   &&  \
-          python3.7 -m pip install Cython                                   &&  \
-          python3.7 -m pip install -r requirements.txt                      &&  \
+          python3.8 -m pip install Cython                                   &&  \
+          python3.8 -m pip install -r requirements.txt                      &&  \
           ./scripts/install_pkgs.sh -y                                      &&  \
           ./scripts/install_third_party.sh
 
       # 5. Build
       - name: catkin build
         run: |
-          source /opt/ros/melodic/setup.bash                                &&  \
+          source /opt/ros/$ROS_DISTRO/setup.bash                            &&  \
           cd catkin_ws/src/zaWRka-project                                   &&  \
           ./scripts/build.sh

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -33,7 +33,7 @@
 
 ### Преднастройка
 
-- Установите требуемые пакеты командой `./scripts/install_packages.sh`
+- Установите требуемые пакеты командой `./scripts/install_pkgs.sh`
 - Установите пакеты для сборки командой `./scripts/install_third_party.sh`
 - Соберите требуемые пакеты командой `./scripts/build.sh`
 

--- a/scripts/install_pkgs.sh
+++ b/scripts/install_pkgs.sh
@@ -33,5 +33,5 @@ sudo apt install ros-$ROS_DISTRO-base-local-planner \
 					ros-$ROS_DISTRO-teb-local-planner \
 					ros-$ROS_DISTRO-hector-slam \
 					libsuitesparse-dev \
-					$1 && \
+					$@ && \
 sudo apt remove ros-$ROS_DISTRO-key-teleop

--- a/scripts/install_pkgs.sh
+++ b/scripts/install_pkgs.sh
@@ -33,5 +33,5 @@ sudo apt install ros-$ROS_DISTRO-base-local-planner \
 					ros-$ROS_DISTRO-teb-local-planner \
 					ros-$ROS_DISTRO-hector-slam \
 					libsuitesparse-dev \
-					&& \
+					$1 && \
 sudo apt remove ros-$ROS_DISTRO-key-teleop


### PR DESCRIPTION
I've added a simple catkin build workflow using GitHub actions based on `DEVELOPMENT.md`.
Here I've also fixed `DEVELOPMENT.md` because it had a wrong installation script name and added an ability to throw "-y" for install_pkgs.sh script to make it usable during the workflow.
Although this workflow is based on Ubuntu-18.04, it might be changed to 20.04 in future if it will be required for somebody.